### PR TITLE
Implement compare functions for each operations

### DIFF
--- a/src/f128.rs
+++ b/src/f128.rs
@@ -77,6 +77,26 @@ impl Float for F128 {
         Self(ret)
     }
 
+    fn eq<T: Borrow<Self>>(&self, x: T) -> bool {
+        unsafe { softfloat_sys_riscv::f128_eq(self.0, x.borrow().0) }
+    }
+
+    fn lt<T: Borrow<Self>>(&self, x: T) -> bool {
+        unsafe { softfloat_sys_riscv::f128_lt(self.0, x.borrow().0) }
+    }
+
+    fn le<T: Borrow<Self>>(&self, x: T) -> bool {
+        unsafe { softfloat_sys_riscv::f128_le(self.0, x.borrow().0) }
+    }
+
+    fn lt_quiet<T: Borrow<Self>>(&self, x: T) -> bool {
+        unsafe { softfloat_sys_riscv::f128_lt_quiet(self.0, x.borrow().0) }
+    }
+
+    fn le_quiet<T: Borrow<Self>>(&self, x: T) -> bool {
+        unsafe { softfloat_sys_riscv::f128_le_quiet(self.0, x.borrow().0) }
+    }
+
     fn compare<T: Borrow<Self>>(&self, x: T) -> Option<Ordering> {
         let eq = unsafe { softfloat_sys::f128_eq(self.0, x.borrow().0) };
         let lt = unsafe { softfloat_sys::f128_lt(self.0, x.borrow().0) };

--- a/src/f128.rs
+++ b/src/f128.rs
@@ -78,23 +78,23 @@ impl Float for F128 {
     }
 
     fn eq<T: Borrow<Self>>(&self, x: T) -> bool {
-        unsafe { softfloat_sys_riscv::f128_eq(self.0, x.borrow().0) }
+        unsafe { softfloat_sys::f128_eq(self.0, x.borrow().0) }
     }
 
     fn lt<T: Borrow<Self>>(&self, x: T) -> bool {
-        unsafe { softfloat_sys_riscv::f128_lt(self.0, x.borrow().0) }
+        unsafe { softfloat_sys::f128_lt(self.0, x.borrow().0) }
     }
 
     fn le<T: Borrow<Self>>(&self, x: T) -> bool {
-        unsafe { softfloat_sys_riscv::f128_le(self.0, x.borrow().0) }
+        unsafe { softfloat_sys::f128_le(self.0, x.borrow().0) }
     }
 
     fn lt_quiet<T: Borrow<Self>>(&self, x: T) -> bool {
-        unsafe { softfloat_sys_riscv::f128_lt_quiet(self.0, x.borrow().0) }
+        unsafe { softfloat_sys::f128_lt_quiet(self.0, x.borrow().0) }
     }
 
     fn le_quiet<T: Borrow<Self>>(&self, x: T) -> bool {
-        unsafe { softfloat_sys_riscv::f128_le_quiet(self.0, x.borrow().0) }
+        unsafe { softfloat_sys::f128_le_quiet(self.0, x.borrow().0) }
     }
 
     fn compare<T: Borrow<Self>>(&self, x: T) -> Option<Ordering> {

--- a/src/f16.rs
+++ b/src/f16.rs
@@ -72,6 +72,26 @@ impl Float for F16 {
         Self(ret)
     }
 
+    fn eq<T: Borrow<Self>>(&self, x: T) -> bool {
+        unsafe { softfloat_sys_riscv::f16_eq(self.0, x.borrow().0) }
+    }
+
+    fn lt<T: Borrow<Self>>(&self, x: T) -> bool {
+        unsafe { softfloat_sys_riscv::f16_lt(self.0, x.borrow().0) }
+    }
+
+    fn le<T: Borrow<Self>>(&self, x: T) -> bool {
+        unsafe { softfloat_sys_riscv::f16_le(self.0, x.borrow().0) }
+    }
+
+    fn lt_quiet<T: Borrow<Self>>(&self, x: T) -> bool {
+        unsafe { softfloat_sys_riscv::f16_lt_quiet(self.0, x.borrow().0) }
+    }
+
+    fn le_quiet<T: Borrow<Self>>(&self, x: T) -> bool {
+        unsafe { softfloat_sys_riscv::f16_le_quiet(self.0, x.borrow().0) }
+    }
+
     fn compare<T: Borrow<Self>>(&self, x: T) -> Option<Ordering> {
         let eq = unsafe { softfloat_sys::f16_eq(self.0, x.borrow().0) };
         let lt = unsafe { softfloat_sys::f16_lt(self.0, x.borrow().0) };

--- a/src/f16.rs
+++ b/src/f16.rs
@@ -73,23 +73,23 @@ impl Float for F16 {
     }
 
     fn eq<T: Borrow<Self>>(&self, x: T) -> bool {
-        unsafe { softfloat_sys_riscv::f16_eq(self.0, x.borrow().0) }
+        unsafe { softfloat_sys::f16_eq(self.0, x.borrow().0) }
     }
 
     fn lt<T: Borrow<Self>>(&self, x: T) -> bool {
-        unsafe { softfloat_sys_riscv::f16_lt(self.0, x.borrow().0) }
+        unsafe { softfloat_sys::f16_lt(self.0, x.borrow().0) }
     }
 
     fn le<T: Borrow<Self>>(&self, x: T) -> bool {
-        unsafe { softfloat_sys_riscv::f16_le(self.0, x.borrow().0) }
+        unsafe { softfloat_sys::f16_le(self.0, x.borrow().0) }
     }
 
     fn lt_quiet<T: Borrow<Self>>(&self, x: T) -> bool {
-        unsafe { softfloat_sys_riscv::f16_lt_quiet(self.0, x.borrow().0) }
+        unsafe { softfloat_sys::f16_lt_quiet(self.0, x.borrow().0) }
     }
 
     fn le_quiet<T: Borrow<Self>>(&self, x: T) -> bool {
-        unsafe { softfloat_sys_riscv::f16_le_quiet(self.0, x.borrow().0) }
+        unsafe { softfloat_sys::f16_le_quiet(self.0, x.borrow().0) }
     }
 
     fn compare<T: Borrow<Self>>(&self, x: T) -> Option<Ordering> {

--- a/src/f32.rs
+++ b/src/f32.rs
@@ -73,23 +73,23 @@ impl Float for F32 {
     }
 
     fn eq<T: Borrow<Self>>(&self, x: T) -> bool {
-        unsafe { softfloat_sys_riscv::f32_eq(self.0, x.borrow().0) }
+        unsafe { softfloat_sys::f32_eq(self.0, x.borrow().0) }
     }
 
     fn lt<T: Borrow<Self>>(&self, x: T) -> bool {
-        unsafe { softfloat_sys_riscv::f32_lt(self.0, x.borrow().0) }
+        unsafe { softfloat_sys::f32_lt(self.0, x.borrow().0) }
     }
 
     fn le<T: Borrow<Self>>(&self, x: T) -> bool {
-        unsafe { softfloat_sys_riscv::f32_le(self.0, x.borrow().0) }
+        unsafe { softfloat_sys::f32_le(self.0, x.borrow().0) }
     }
 
     fn lt_quiet<T: Borrow<Self>>(&self, x: T) -> bool {
-        unsafe { softfloat_sys_riscv::f32_lt_quiet(self.0, x.borrow().0) }
+        unsafe { softfloat_sys::f32_lt_quiet(self.0, x.borrow().0) }
     }
 
     fn le_quiet<T: Borrow<Self>>(&self, x: T) -> bool {
-        unsafe { softfloat_sys_riscv::f32_le_quiet(self.0, x.borrow().0) }
+        unsafe { softfloat_sys::f32_le_quiet(self.0, x.borrow().0) }
     }
 
     fn compare<T: Borrow<Self>>(&self, x: T) -> Option<Ordering> {

--- a/src/f32.rs
+++ b/src/f32.rs
@@ -72,6 +72,26 @@ impl Float for F32 {
         Self(ret)
     }
 
+    fn eq<T: Borrow<Self>>(&self, x: T) -> bool {
+        unsafe { softfloat_sys_riscv::f32_eq(self.0, x.borrow().0) }
+    }
+
+    fn lt<T: Borrow<Self>>(&self, x: T) -> bool {
+        unsafe { softfloat_sys_riscv::f32_lt(self.0, x.borrow().0) }
+    }
+
+    fn le<T: Borrow<Self>>(&self, x: T) -> bool {
+        unsafe { softfloat_sys_riscv::f32_le(self.0, x.borrow().0) }
+    }
+
+    fn lt_quiet<T: Borrow<Self>>(&self, x: T) -> bool {
+        unsafe { softfloat_sys_riscv::f32_lt_quiet(self.0, x.borrow().0) }
+    }
+
+    fn le_quiet<T: Borrow<Self>>(&self, x: T) -> bool {
+        unsafe { softfloat_sys_riscv::f32_le_quiet(self.0, x.borrow().0) }
+    }
+
     fn compare<T: Borrow<Self>>(&self, x: T) -> Option<Ordering> {
         let eq = unsafe { softfloat_sys::f32_eq(self.0, x.borrow().0) };
         let lt = unsafe { softfloat_sys::f32_lt(self.0, x.borrow().0) };

--- a/src/f64.rs
+++ b/src/f64.rs
@@ -73,23 +73,23 @@ impl Float for F64 {
     }
 
     fn eq<T: Borrow<Self>>(&self, x: T) -> bool {
-        unsafe { softfloat_sys_riscv::f64_eq(self.0, x.borrow().0) }
+        unsafe { softfloat_sys::f64_eq(self.0, x.borrow().0) }
     }
 
     fn lt<T: Borrow<Self>>(&self, x: T) -> bool {
-        unsafe { softfloat_sys_riscv::f64_lt(self.0, x.borrow().0) }
+        unsafe { softfloat_sys::f64_lt(self.0, x.borrow().0) }
     }
 
     fn le<T: Borrow<Self>>(&self, x: T) -> bool {
-        unsafe { softfloat_sys_riscv::f64_le(self.0, x.borrow().0) }
+        unsafe { softfloat_sys::f64_le(self.0, x.borrow().0) }
     }
 
     fn lt_quiet<T: Borrow<Self>>(&self, x: T) -> bool {
-        unsafe { softfloat_sys_riscv::f64_lt_quiet(self.0, x.borrow().0) }
+        unsafe { softfloat_sys::f64_lt_quiet(self.0, x.borrow().0) }
     }
 
     fn le_quiet<T: Borrow<Self>>(&self, x: T) -> bool {
-        unsafe { softfloat_sys_riscv::f64_le_quiet(self.0, x.borrow().0) }
+        unsafe { softfloat_sys::f64_le_quiet(self.0, x.borrow().0) }
     }
 
     fn compare<T: Borrow<Self>>(&self, x: T) -> Option<Ordering> {

--- a/src/f64.rs
+++ b/src/f64.rs
@@ -72,6 +72,26 @@ impl Float for F64 {
         Self(ret)
     }
 
+    fn eq<T: Borrow<Self>>(&self, x: T) -> bool {
+        unsafe { softfloat_sys_riscv::f64_eq(self.0, x.borrow().0) }
+    }
+
+    fn lt<T: Borrow<Self>>(&self, x: T) -> bool {
+        unsafe { softfloat_sys_riscv::f64_lt(self.0, x.borrow().0) }
+    }
+
+    fn le<T: Borrow<Self>>(&self, x: T) -> bool {
+        unsafe { softfloat_sys_riscv::f64_le(self.0, x.borrow().0) }
+    }
+
+    fn lt_quiet<T: Borrow<Self>>(&self, x: T) -> bool {
+        unsafe { softfloat_sys_riscv::f64_lt_quiet(self.0, x.borrow().0) }
+    }
+
+    fn le_quiet<T: Borrow<Self>>(&self, x: T) -> bool {
+        unsafe { softfloat_sys_riscv::f64_le_quiet(self.0, x.borrow().0) }
+    }
+
     fn compare<T: Borrow<Self>>(&self, x: T) -> Option<Ordering> {
         let eq = unsafe { softfloat_sys::f64_eq(self.0, x.borrow().0) };
         let lt = unsafe { softfloat_sys::f64_lt(self.0, x.borrow().0) };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,6 +186,16 @@ pub trait Float {
 
     fn sqrt(&self, rnd: RoundingMode) -> Self;
 
+    fn eq<T: Borrow<Self>>(&self, x: T) -> bool;
+
+    fn lt<T: Borrow<Self>>(&self, x: T) -> bool;
+
+    fn le<T: Borrow<Self>>(&self, x: T) -> bool;
+
+    fn lt_quiet<T: Borrow<Self>>(&self, x: T) -> bool;
+
+    fn le_quiet<T: Borrow<Self>>(&self, x: T) -> bool;
+
     fn compare<T: Borrow<Self>>(&self, x: T) -> Option<Ordering>;
 
     fn from_u32(x: u32, rnd: RoundingMode) -> Self;


### PR DESCRIPTION
This PR is to recognize the difference of flag operations in each compare functions.

Currently, `compare` execute two softfloat functions `fxx_eq` and `fxx_lt` but flag raising conditions are different so correct flag can't be set
```rust
    fn compare<T: Borrow<Self>>(&self, x: T) -> Option<Ordering> {
        let eq = unsafe { softfloat_sys::f64_eq(self.0, x.borrow().0) };
        let lt = unsafe { softfloat_sys::f64_lt(self.0, x.borrow().0) };
```

- `f64_eq.c`

```cpp
    if ( isNaNF64UI( uiA ) || isNaNF64UI( uiB ) ) {
        if (
            softfloat_isSigNaNF64UI( uiA ) || softfloat_isSigNaNF64UI( uiB )
        ) {
            softfloat_raiseFlags( softfloat_flag_invalid );
        }
        return false;
```

- `f64_lt.c`

```cpp
    if ( isNaNF64UI( uiA ) || isNaNF64UI( uiB ) ) {
        softfloat_raiseFlags( softfloat_flag_invalid );
        return false;
    }
```

So this PR is defining explicit compare operation functions, to get correct flag result.
`eq()`, `lt()`, `le()`, `lt_quiet()`, `le_quiet()` execute softfloat function only one time, so it can keep correct flag information.
