### PR TITLE
Support exact operations on fcvt

### DIFF
--- a/src/f128.rs
+++ b/src/f128.rs
@@ -120,23 +120,23 @@ impl Float for F128 {
         Self(ret)
     }
 
-    fn to_u32(&self, rnd: RoundingMode) -> u32 {
-        let ret = unsafe { softfloat_sys::f128_to_ui32(self.0, rnd.to_softfloat(), false) };
+    fn to_u32(&self, rnd: RoundingMode, exact: bool) -> u32 {
+        let ret = unsafe { softfloat_sys::f128_to_ui32(self.0, rnd.to_softfloat(), exact) };
         ret as u32
     }
 
-    fn to_u64(&self, rnd: RoundingMode) -> u64 {
-        let ret = unsafe { softfloat_sys::f128_to_ui64(self.0, rnd.to_softfloat(), false) };
+    fn to_u64(&self, rnd: RoundingMode, exact: bool) -> u64 {
+        let ret = unsafe { softfloat_sys::f128_to_ui64(self.0, rnd.to_softfloat(), exact) };
         ret
     }
 
-    fn to_i32(&self, rnd: RoundingMode) -> i32 {
-        let ret = unsafe { softfloat_sys::f128_to_i32(self.0, rnd.to_softfloat(), false) };
+    fn to_i32(&self, rnd: RoundingMode, exact: bool) -> i32 {
+        let ret = unsafe { softfloat_sys::f128_to_i32(self.0, rnd.to_softfloat(), exact) };
         ret as i32
     }
 
-    fn to_i64(&self, rnd: RoundingMode) -> i64 {
-        let ret = unsafe { softfloat_sys::f128_to_i64(self.0, rnd.to_softfloat(), false) };
+    fn to_i64(&self, rnd: RoundingMode, exact: bool) -> i64 {
+        let ret = unsafe { softfloat_sys::f128_to_i64(self.0, rnd.to_softfloat(), exact) };
         ret
     }
 

--- a/src/f16.rs
+++ b/src/f16.rs
@@ -115,23 +115,23 @@ impl Float for F16 {
         Self(ret)
     }
 
-    fn to_u32(&self, rnd: RoundingMode) -> u32 {
-        let ret = unsafe { softfloat_sys::f16_to_ui32(self.0, rnd.to_softfloat(), false) };
+    fn to_u32(&self, rnd: RoundingMode, exact: bool) -> u32 {
+        let ret = unsafe { softfloat_sys::f16_to_ui32(self.0, rnd.to_softfloat(), exact) };
         ret as u32
     }
 
-    fn to_u64(&self, rnd: RoundingMode) -> u64 {
-        let ret = unsafe { softfloat_sys::f16_to_ui64(self.0, rnd.to_softfloat(), false) };
+    fn to_u64(&self, rnd: RoundingMode, exact: bool) -> u64 {
+        let ret = unsafe { softfloat_sys::f16_to_ui64(self.0, rnd.to_softfloat(), exact) };
         ret
     }
 
-    fn to_i32(&self, rnd: RoundingMode) -> i32 {
-        let ret = unsafe { softfloat_sys::f16_to_i32(self.0, rnd.to_softfloat(), false) };
+    fn to_i32(&self, rnd: RoundingMode, exact: bool) -> i32 {
+        let ret = unsafe { softfloat_sys::f16_to_i32(self.0, rnd.to_softfloat(), exact) };
         ret as i32
     }
 
-    fn to_i64(&self, rnd: RoundingMode) -> i64 {
-        let ret = unsafe { softfloat_sys::f16_to_i64(self.0, rnd.to_softfloat(), false) };
+    fn to_i64(&self, rnd: RoundingMode, exact: bool) -> i64 {
+        let ret = unsafe { softfloat_sys::f16_to_i64(self.0, rnd.to_softfloat(), exact) };
         ret
     }
 

--- a/src/f32.rs
+++ b/src/f32.rs
@@ -115,23 +115,23 @@ impl Float for F32 {
         Self(ret)
     }
 
-    fn to_u32(&self, rnd: RoundingMode) -> u32 {
-        let ret = unsafe { softfloat_sys::f32_to_ui32(self.0, rnd.to_softfloat(), false) };
+    fn to_u32(&self, rnd: RoundingMode, exact: bool) -> u32 {
+        let ret = unsafe { softfloat_sys::f32_to_ui32(self.0, rnd.to_softfloat(), exact) };
         ret as u32
     }
 
-    fn to_u64(&self, rnd: RoundingMode) -> u64 {
-        let ret = unsafe { softfloat_sys::f32_to_ui64(self.0, rnd.to_softfloat(), false) };
+    fn to_u64(&self, rnd: RoundingMode, exact: bool) -> u64 {
+        let ret = unsafe { softfloat_sys::f32_to_ui64(self.0, rnd.to_softfloat(), exact) };
         ret
     }
 
-    fn to_i32(&self, rnd: RoundingMode) -> i32 {
-        let ret = unsafe { softfloat_sys::f32_to_i32(self.0, rnd.to_softfloat(), false) };
+    fn to_i32(&self, rnd: RoundingMode, exact: bool) -> i32 {
+        let ret = unsafe { softfloat_sys::f32_to_i32(self.0, rnd.to_softfloat(), exact) };
         ret as i32
     }
 
-    fn to_i64(&self, rnd: RoundingMode) -> i64 {
-        let ret = unsafe { softfloat_sys::f32_to_i64(self.0, rnd.to_softfloat(), false) };
+    fn to_i64(&self, rnd: RoundingMode, exact: bool) -> i64 {
+        let ret = unsafe { softfloat_sys::f32_to_i64(self.0, rnd.to_softfloat(), exact) };
         ret
     }
 

--- a/src/f64.rs
+++ b/src/f64.rs
@@ -115,23 +115,23 @@ impl Float for F64 {
         Self(ret)
     }
 
-    fn to_u32(&self, rnd: RoundingMode) -> u32 {
-        let ret = unsafe { softfloat_sys::f64_to_ui32(self.0, rnd.to_softfloat(), false) };
+    fn to_u32(&self, rnd: RoundingMode, exact: bool) -> u32 {
+        let ret = unsafe { softfloat_sys::f64_to_ui32(self.0, rnd.to_softfloat(), exact) };
         ret as u32
     }
 
-    fn to_u64(&self, rnd: RoundingMode) -> u64 {
-        let ret = unsafe { softfloat_sys::f64_to_ui64(self.0, rnd.to_softfloat(), false) };
+    fn to_u64(&self, rnd: RoundingMode, exact: bool) -> u64 {
+        let ret = unsafe { softfloat_sys::f64_to_ui64(self.0, rnd.to_softfloat(), exact) };
         ret
     }
 
-    fn to_i32(&self, rnd: RoundingMode) -> i32 {
-        let ret = unsafe { softfloat_sys::f64_to_i32(self.0, rnd.to_softfloat(), false) };
+    fn to_i32(&self, rnd: RoundingMode, exact: bool) -> i32 {
+        let ret = unsafe { softfloat_sys::f64_to_i32(self.0, rnd.to_softfloat(), exact) };
         ret as i32
     }
 
-    fn to_i64(&self, rnd: RoundingMode) -> i64 {
-        let ret = unsafe { softfloat_sys::f64_to_i64(self.0, rnd.to_softfloat(), false) };
+    fn to_i64(&self, rnd: RoundingMode, exact: bool) -> i64 {
+        let ret = unsafe { softfloat_sys::f64_to_i64(self.0, rnd.to_softfloat(), exact) };
         ret
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,13 +204,13 @@ pub trait Float {
 
     fn from_i64(x: i64, rnd: RoundingMode) -> Self;
 
-    fn to_u32(&self, rnd: RoundingMode) -> u32;
+    fn to_u32(&self, rnd: RoundingMode, exact: bool) -> u32;
 
-    fn to_u64(&self, rnd: RoundingMode) -> u64;
+    fn to_u64(&self, rnd: RoundingMode, exact: bool) -> u64;
 
-    fn to_i32(&self, rnd: RoundingMode) -> i32;
+    fn to_i32(&self, rnd: RoundingMode, exact: bool) -> i32;
 
-    fn to_i64(&self, rnd: RoundingMode) -> i64;
+    fn to_i64(&self, rnd: RoundingMode, exact: bool) -> i64;
 
     fn to_f16(&self, rnd: RoundingMode) -> F16;
 


### PR DESCRIPTION
Supporting `exact` option in `FCVT` operations. 
Added `exact` argument to support raise flags in `to_u32()`, `to_u64()`, `to_i32()`, `to_i64()` .

